### PR TITLE
test(kafka): improve assertion in AddBookListenerTest

### DIFF
--- a/kafka/src/test/java/io/github/atomfinger/javazone/bookstore/kafka/acceptance_test/AddBookListenerTest.java
+++ b/kafka/src/test/java/io/github/atomfinger/javazone/bookstore/kafka/acceptance_test/AddBookListenerTest.java
@@ -30,7 +30,7 @@ class AddBookListenerTest extends AcceptanceTestBase {
 
     private void sendMessage() throws InterruptedException {
         kafkaTemplate().send("bookstore.cmd.add-book.1", "key", createMessage());
-        await().atMost(30, SECONDS).until(() -> bookRepository.count() > 0);
+        await().atMost(30, SECONDS).untilAsserted(() -> assertThat(bookRepository.count()).isNotZero());
         assertThat(consumer.getLatch().await(20, SECONDS)).isTrue();
     }
 


### PR DESCRIPTION
Replace generic count check with explicit assertion to ensure
bookRepository contains entries. This enhances test reliability
by making failure conditions clearer and improving readability.