### PR TITLE
test(kafka): increase wait time for book addition assertion

### DIFF
--- a/kafka/src/test/java/io/github/atomfinger/javazone/bookstore/kafka/acceptance_test/AddBookListenerTest.java
+++ b/kafka/src/test/java/io/github/atomfinger/javazone/bookstore/kafka/acceptance_test/AddBookListenerTest.java
@@ -30,7 +30,7 @@ class AddBookListenerTest extends AcceptanceTestBase {
 
     private void sendMessage() throws InterruptedException {
         kafkaTemplate().send("bookstore.cmd.add-book.1", "key", createMessage());
-        await().atMost(30, SECONDS).untilAsserted(() -> assertThat(bookRepository.count()).isNotZero());
+        await().atMost(90, SECONDS).untilAsserted(() -> assertThat(bookRepository.count()).isNotZero());
         assertThat(consumer.getLatch().await(20, SECONDS)).isTrue();
     }
 


### PR DESCRIPTION
Extend the await timeout from 30 to 90 seconds in AddBookListenerTest
to allow more time for the bookRepository count to update. This change
addresses intermittent test failures caused by timing issues in Kafka
message processing during acceptance tests.