### PR TITLE
config: migrate from dependabot to renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-    - package-ecosystem: "gradle"
-      directory: "/"
-      schedule:
-          interval: "weekly"
-      rebase-strategy: "disabled"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "schedule": ["every weekend"],
+  "labels": ["dependencies"],
+  "gradle": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "groupName": "Gradle dependencies"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    }
+  ]
+}


### PR DESCRIPTION
Replace dependabot configuration with renovate for improved
dependency management. Renovate provides better grouping of
related updates and more flexible scheduling options. Configure
renovate to run weekly, group gradle and github-actions updates
separately, and label all dependency updates for easier tracking.