### PR TITLE
feat: add macOS .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/gradle,intellij+all,java
 .settings
+
+### macOS ###
+.DS_Store


### PR DESCRIPTION
Add .DS_Store to the gitignore file to prevent macOS system files from being tracked in version control. This file is automatically generated by macOS and should not be committed to the repository.